### PR TITLE
update case statement syntax for Ruby 1.9

### DIFF
--- a/lib/foto_verite/package.rb
+++ b/lib/foto_verite/package.rb
@@ -45,18 +45,24 @@ module FotoVerite #:nodoc:
 
     def ounces(options={})
       case options[:type]
-      when *[nil,:actual]: @ounces ||= grams(options) * OUNCES_IN_A_GRAM
-      when *[:volumetric,:dimensional]: @volumetric_ounces ||= grams(options) * OUNCES_IN_A_GRAM
-      when :billable: @billable_ounces ||= [ounces,ounces(:type => :volumetric)].max
+      when *[nil,:actual]
+        @ounces ||= grams(options) * OUNCES_IN_A_GRAM
+      when *[:volumetric,:dimensional]
+        @volumetric_ounces ||= grams(options) * OUNCES_IN_A_GRAM
+      when :billable
+        @billable_ounces ||= [ounces,ounces(:type => :volumetric)].max
       end
     end
     alias_method :oz, :ounces
 
     def grams(options={})
       case options[:type]
-      when *[nil,:actual]: @grams ||= ounces(options) * GRAMS_IN_AN_OUNCE
-      when *[:volumetric,:dimensional]: @volumetric_grams ||= centimetres(:box_volume) / 6.0
-      when :billable: [grams,grams(:type => :volumetric)].max
+      when *[nil,:actual]
+        @grams ||= ounces(options) * GRAMS_IN_AN_OUNCE
+      when *[:volumetric,:dimensional]
+        @volumetric_grams ||= centimetres(:box_volume) / 6.0
+      when :billable
+        [grams,grams(:type => :volumetric)].max
       end
     end
     alias_method :g, :grams
@@ -106,14 +112,20 @@ module FotoVerite #:nodoc:
 
   def measure(measurement, ary)
     case measurement
-    when Fixnum: ary[measurement]
-    when *[:x,:max,:length,:long]: ary[2]
-    when *[:y,:mid,:width,:wide]: ary[1]
-    when *[:z,:min,:height,:depth,:high,:deep]: ary[0]
+    when Fixnum
+      ary[measurement]
+    when *[:x,:max,:length,:long]
+      ary[2]
+    when *[:y,:mid,:width,:wide]
+      ary[1]
+    when *[:z,:min,:height,:depth,:high,:deep]
+      ary[0]
     when *[:girth,:around,:circumference]
       self.cylinder? ? (Math::PI * (ary[0] + ary[1]) / 2) : (2 * ary[0]) + (2 * ary[1])
-    when :volume: self.cylinder? ? (Math::PI * (ary[0] + ary[1]) / 4)**2 * ary[2] : measure(:box_volume,ary)
-    when :box_volume: ary[0] * ary[1] * ary[2]
+    when :volume
+      self.cylinder? ? (Math::PI * (ary[0] + ary[1]) / 4)**2 * ary[2] : measure(:box_volume,ary)
+    when :box_volume
+      ary[0] * ary[1] * ary[2]
     end
   end
 


### PR DESCRIPTION
This fixes the syntax errors under Ruby 1.9. Specifically, it gets rid of the "when value: ..." form that Ruby 1.9 no longer allows.
